### PR TITLE
Fixed broken link to code of conduct

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ If you’d like to contribute, see our [guidelines](.github/CONTRIBUTING.md).
 ## Code of Conduct
 
 Please note that this curriculum is released with a
-[Contributor Code of Conduct](.github/CODE_OF_CONDUCT.MD).
+[Contributor Code of Conduct](.github/CODE_OF_CONDUCT.md).
 By contributing to this project, you agree to abide by its terms.
 
 ## Citation


### PR DESCRIPTION
During the review: https://github.com/openjournals/jose-reviews/issues/138, I found a broken link to the code of conduct which I propose a fix for here.